### PR TITLE
Update testcase one to match intent

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -38,7 +38,7 @@ const legacyReferenceHeadersSignature = Buffer.from(
 )
 
 test("gets data length of secret 1 as string", async () => {
-  const dataLength = getDataLength(Buffer.from(secrets[0].message))
+  const dataLength = getDataLength(secrets[0].message)
   expect(dataLength).toEqual(184)
 })
 


### PR DESCRIPTION
- Testcase 1 and 2 are equivalent. This refactors testcase 1 to match intent. 
- Tests are passing as expected. 

Run Test:
```
npm install . 
npm audit fix
npm run build
npm run test
```

Output:
```diff
+ Test Suites: 1 passed, 1 total
+ Tests:       20 passed, 20 total
+ Snapshots:   0 total
+ Time:        0.182 s, estimated 1 s
+ Ran all test suites matching /dist\/test.js/i.
```

Notes:
Highly recommend running `npm audit fix` as there are vulnerabilities. 

npm audit logs:
```
npm audit
# npm audit report

@babel/helpers  <7.26.10
Severity: moderate
Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8
fix available via `npm audit fix`
node_modules/@babel/helpers

cross-spawn  7.0.0 - 7.0.4
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix`
node_modules/cross-spawn

2 vulnerabilities (1 moderate, 1 high)
```